### PR TITLE
Remove namespace, add small fixes

### DIFF
--- a/stable/metallb/templates/config.yaml
+++ b/stable/metallb/templates/config.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -12,7 +11,7 @@ metadata:
 data:
   config: |
 {{- if .Values.config }}
-{{ toYaml .Values.override_config | indent 4 }}
+{{ toYaml .Values.config | indent 4 }}
 {{- else }}
     address-pools:
     - name: default

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -1,8 +1,7 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
-  name: {{ template "metallb.fullname" . }}
+  name: {{ template "metallb.fullname" . }}-controller
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -41,8 +40,8 @@ spec:
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         args:
         - --port=7472
-        - --config-ns={{ .Release.Namespace | quote }}
-        - --config="{{ template "metallb.fullname" . }}"
+        - --config-ns={{ .Release.Namespace }}
+        - --config={{ template "metallb.fullname" . }}
         ports:
         - name: monitoring
           containerPort: 7472

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -38,7 +38,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-leader-election
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -57,7 +56,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -85,8 +83,8 @@ metadata:
     app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.controllerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -103,8 +101,8 @@ metadata:
     app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.speakerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -113,7 +111,6 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -133,7 +130,6 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-leader-election
   labels:
     heritage: {{ .Release.Service | quote }}

--- a/stable/metallb/templates/service-accounts.yaml
+++ b/stable/metallb/templates/service-accounts.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.controllerServiceAccountName" . }}
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -15,7 +14,6 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.speakerServiceAccountName" . }}
   labels:
     heritage: {{ .Release.Service | quote }}

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -1,8 +1,7 @@
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
-  name: {{ template "metallb.fullname" . }}
+  name: {{ template "metallb.fullname" . }}-speaker
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -38,8 +37,8 @@ spec:
         imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
         args:
         - --port=7472
-        - --config-ns={{ .Release.Namespace | quote }}
-        - --config="{{ template "metallb.fullname" . }}"
+        - --config-ns={{ .Release.Namespace }}
+        - --config={{ template "metallb.fullname" . }}
         env:
         - name: METALLB_NODE_IP
           valueFrom:


### PR DESCRIPTION
This PR:
* Removes unnecessary namespace references from templates
* Removes two kinds of quoting around container arguments. For me, the quoting lead to malformed requests to the kubernetes API and metallb not correctly retrieving its config. 